### PR TITLE
refactor: remove implicit map keys

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,13 +41,13 @@ resource "azuread_application" "this" {
 
   api {
     dynamic "oauth2_permission_scope" {
-      for_each = { for scope in var.oauth2_permission_scopes : scope.value => scope }
+      for_each = var.oauth2_permission_scopes
       content {
         admin_consent_description  = oauth2_permission_scope.value.admin_consent_description
         admin_consent_display_name = oauth2_permission_scope.value.admin_consent_display_name
 
         enabled = oauth2_permission_scope.value.enabled
-        id      = random_uuid.scope_id[oauth2_permission_scope.key].result
+        id      = random_uuid.oauth2_permission_scope[oauth2_permission_scope.key].result
         type    = oauth2_permission_scope.value.type
 
         user_consent_description  = oauth2_permission_scope.value.user_consent_description
@@ -69,8 +69,8 @@ resource "azuread_application" "this" {
   }
 }
 
-resource "random_uuid" "scope_id" {
-  for_each = { for scope in var.oauth2_permission_scopes : scope.value => scope }
+resource "random_uuid" "oauth2_permission_scope" {
+  count = length(var.oauth2_permission_scopes)
 }
 
 resource "azuread_application_identifier_uri" "default" {

--- a/main.tf
+++ b/main.tf
@@ -79,10 +79,10 @@ resource "azuread_application_identifier_uri" "default" {
 }
 
 resource "azuread_application_identifier_uri" "extra" {
-  for_each = { for url in var.identifier_uris : url => url }
+  count = length(var.identifier_uris)
 
   application_id = azuread_application.this.id
-  identifier_uri = each.value
+  identifier_uri = var.identifier_uris[count.index]
 }
 
 resource "azuread_service_principal" "this" {


### PR DESCRIPTION
Setting an unknown value as an implicit map key can be flaky, as it requires said random value to be known during the planning phase. We don't know for sure if this value is always known during planning.

Use the count meta-argument to create repeatable unnamed resources, according to our own [best practices](https://equinor.github.io/terraform-baseline/best-practices/resources/#repeatable-resources).
