### PR TITLE
Use principal names (e-mail) instead of GUID when declaring owners

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -22,12 +22,12 @@ variable "identifier_uris" {
 }
 
 variable "service_management_reference" {
-  description = "Reference application context information from a service management datbase, e.g. ServiceNow."
+  description = "Reference application context information from a service management database, e.g. ServiceNow."
   type        = string
 }
 
 variable "owners" {
-  description = "A list of object IDs of owners to set for this application. At least two owners must be set."
+  description = "A list of user principal names (email addresses) of owners to set for this application. At least two owners must be set."
   type        = list(string)
 
   validation {


### PR DESCRIPTION
Declare owners as a list of emails (principal names) instead of object ids.

Terraform will lookup object ids by principal names provided and use object ids behind the scenes, but makes it easier for the developers to work with emails.