### PR TITLE
refactor: rename variables and outputs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ data "azuread_client_config" "current" {}
 # that you'll need Entra ID role "Application Administrator" or "Global Administrator" to make further changes to the
 # application (including configuring yourself as owner).
 resource "azuread_application" "this" {
-  display_name                   = var.display_name
+  display_name                   = var.application_display_name
   service_management_reference   = var.service_management_reference
   owners                         = var.owners
   device_only_auth_enabled       = var.device_only_auth_enabled

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
-output "object_id" {
+output "application_object_id" {
   description = "The object ID of this application."
   value       = azuread_application.this.object_id
 }
 
-output "client_id" {
+output "application_client_id" {
   description = "The client ID of this application."
   value       = azuread_application.this.client_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "application_display_name" {
+  description = "The display name of this application."
+  type        = string
+}
+
 variable "app_roles" {
   description = "A map of application roles to configure for this application."
   type = list(object({
@@ -9,11 +14,6 @@ variable "app_roles" {
     value                = string
   }))
   default = []
-}
-
-variable "display_name" {
-  description = "The display name of this application."
-  type        = string
 }
 
 variable "device_only_auth_enabled" {


### PR DESCRIPTION
Rename variables according to naming convention.

Shouldn't count as a breaking change, as we are still on a very experimental v0 of this module.