### PR TITLE
fix: validation rule does not correctly reference variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -189,7 +189,7 @@ variable "api_requested_access_token_version" {
   default     = 2
 
   validation {
-    condition     = var.requested_access_token_version == 1 || var.requested_access_token_version == 2
+    condition     = var.api_requested_access_token_version == 1 || var.api_requested_access_token_version == 2
     error_message = "The requested access token version must be either 1 or 2."
   }
 }


### PR DESCRIPTION
The variable api_requested_access_token_version has a validation rule that does not reference the correct variable, leading to this issue 
![image](https://github.com/user-attachments/assets/9056c5b2-a3f9-4851-b159-dbabcb54d043)
