### PR TITLE
fix: output variable api oauth permission scope ids

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,5 @@ output "service_principal_object_id" {
 
 output "api_oauth2_permission_scope_ids" {
   description = "A map of Oauth2 permission scope IDs."
-  value = {
-    for k, v in azuread_application.this.api[0].oauth2_permission_scope : k => v.id
-  }
+  value       = azuread_application.this.oauth2_permission_scope_ids
 }


### PR DESCRIPTION
`azuread_application.this.api[0].oauth2_permission_scope` is a list of objects and not a map, and can therefore not use `for k, v in ..`. I think the best option is to use a map that uses the "value" in the permission scope as a key. This is already provided in the `azuread_application.this.oauth2_permission_scope_ids` atrribute.