### PR TITLE
feat: optional identifier URI configuration 

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -8,7 +8,7 @@ data "azuread_client_config" "current" {}
 
 module "app" {
   source  = "equinor/app/azuread"
-  version = "0.7.0"
+  version = "0.8.0"
 
   application_display_name     = "app-${random_id.example.hex}"
   service_management_reference = "12345"

--- a/main.tf
+++ b/main.tf
@@ -150,13 +150,11 @@ resource "random_uuid" "app_role" {
 }
 
 resource "azuread_application_identifier_uri" "this" {
-  for_each = var.identifier_uris
+  count = var.identifier_uri_enabled ? 1 : 0
 
   application_id = azuread_application.this.id
-  identifier_uri = templatestring(each.value, {
-    app_id    = azuread_application.this.client_id
-    tenant_id = data.azuread_client_config.current.tenant_id
-  })
+  identifier_uri = "api://${azuread_application.this.client_id}"
+  # Ref: https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#identifieruris-attribute
 }
 
 resource "azuread_service_principal" "this" {

--- a/main.tf
+++ b/main.tf
@@ -158,6 +158,7 @@ resource "random_uuid" "app_role" {
 }
 
 resource "azuread_application_identifier_uri" "this" {
+  count = var.application_identifier_uri ? 1 : 0
   for_each = merge(local.identifier_uris, var.identifier_uris)
 
   application_id = azuread_application.this.id

--- a/main.tf
+++ b/main.tf
@@ -150,7 +150,7 @@ resource "random_uuid" "app_role" {
 }
 
 resource "azuread_application_identifier_uri" "this" {
-  count = var.identifier_uri_enabled ? 1 : 0
+  count = var.create_identifier_uri ? 1 : 0
 
   application_id = azuread_application.this.id
   identifier_uri = "api://${azuread_application.this.client_id}"

--- a/variables.tf
+++ b/variables.tf
@@ -34,9 +34,13 @@ variable "group_membership_claims" {
 }
 
 variable "identifier_uris" {
-  description = "A map of user-defined URIs that uniquely identify this application within its Microsoft Entra ID tenant, or within a verified custom domain if this application is multi-tenant."
+  description = "A map of user-defined URIs that uniquely identify this application within its Microsoft Entra ID tenant, or within a verified custom domain if this application is multi-tenant. Values may be a string template. Available variables for the string template are \"app_id\" and \"tenant_id\". For example \"api://$${app_id}\"."
   type        = map(string)
   default     = {}
+  # References:
+  # - String templates: https://developer.hashicorp.com/terraform/language/expressions/strings#string-templates
+  # - templatestring function: https://developer.hashicorp.com/terraform/language/functions/templatestring
+  # - Entra Application identifier URIs: https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#identifieruris-attribute
 }
 
 variable "api_known_client_applications" {
@@ -248,10 +252,4 @@ variable "api_oauth2_permission_scopes" {
     condition     = alltrue([for scope in var.api_oauth2_permission_scopes : scope.type == "User" || scope.type == "Admin"])
     error_message = "Type must be either \"User\" or \"Admin\"."
   }
-}
-
-variable "application_identifier_uri" {
-  description = "Manages a single Identifier URI for an application registration."
-  type        = bool
-  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -249,3 +249,9 @@ variable "api_oauth2_permission_scopes" {
     error_message = "Type must be either \"User\" or \"Admin\"."
   }
 }
+
+variable "application_identifier_uri" {
+  description = "Manages a single Identifier URI for an application registration."
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -33,14 +33,11 @@ variable "group_membership_claims" {
   default     = ["None"]
 }
 
-variable "identifier_uris" {
-  description = "A map of user-defined URIs that uniquely identify this application within its Microsoft Entra ID tenant, or within a verified custom domain if this application is multi-tenant. Values may be a string template. Available variables for the string template are \"app_id\" and \"tenant_id\". For example \"api://$${app_id}\"."
-  type        = map(string)
-  default     = {}
-  # References:
-  # - String templates: https://developer.hashicorp.com/terraform/language/expressions/strings#string-templates
-  # - templatestring function: https://developer.hashicorp.com/terraform/language/functions/templatestring
-  # - Entra Application identifier URIs: https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#identifieruris-attribute
+variable "identifier_uri_enabled" {
+  description = "Should an identifier URI be added to this application? The identifier URI will uniquely identity this application within its Microsoft Entra ID tenant, or within a verified comain if this application is multi-tenant."
+  type        = bool
+  default     = false
+  nullable    = false
 }
 
 variable "api_known_client_applications" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,8 +33,8 @@ variable "group_membership_claims" {
   default     = ["None"]
 }
 
-variable "identifier_uri_enabled" {
-  description = "Should an identifier URI be added to this application? The identifier URI will uniquely identity this application within its Microsoft Entra ID tenant, or within a verified comain if this application is multi-tenant."
+variable "create_identifier_uri" {
+  description = "Should an identifier URI be created and added to this application? The identifier URI will uniquely identity this application within its Microsoft Entra ID tenant, or within a verified comain if this application is multi-tenant."
   type        = bool
   default     = false
   nullable    = false


### PR DESCRIPTION
This makes application identifier URI an optional parameter.
Default is disabled, as a new app registration created manually is also without this.