### PR TITLE
feat: override app role and OAuth2 permission scope IDs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "azuread_application" "this" {
       description          = app_role.value.description
       display_name         = app_role.value.display_name
       enabled              = app_role.value.enabled
-      id                   = app_role.value.id
+      id                   = coalesce(app_role.value.id, random_uuid.app_role[app_role.key].result)
       value                = app_role.value.value
     }
   }
@@ -78,7 +78,7 @@ resource "azuread_application" "this" {
         admin_consent_display_name = oauth2_permission_scope.value.admin_consent_display_name
 
         enabled = oauth2_permission_scope.value.enabled
-        id      = oauth2_permission_scope.value.id
+        id      = coalesce(oauth2_permission_scope.value.id, random_uuid.oauth2_permission_scope[oauth2_permission_scope.key].result)
         type    = oauth2_permission_scope.value.type
 
         user_consent_description  = oauth2_permission_scope.value.user_consent_description
@@ -137,6 +137,16 @@ resource "azuread_application" "this" {
       error_message = "Current client (object ID: \"${data.azuread_client_config.current.object_id}\") must be set as owner."
     }
   }
+}
+
+resource "random_uuid" "oauth2_permission_scope" {
+  // Generate random UUIDs for each permission scope
+  for_each = var.api_oauth2_permission_scopes
+}
+
+resource "random_uuid" "app_role" {
+  // Generate random UUIDs for each app role
+  for_each = var.app_roles
 }
 
 resource "azuread_application_identifier_uri" "this" {

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "azuread_application" "this" {
       description          = app_role.value.description
       display_name         = app_role.value.display_name
       enabled              = app_role.value.enabled
-      id                   = random_uuid.app_role[app_role.key].result
+      id                   = app_role.value.id
       value                = app_role.value.value
     }
   }
@@ -78,7 +78,7 @@ resource "azuread_application" "this" {
         admin_consent_display_name = oauth2_permission_scope.value.admin_consent_display_name
 
         enabled = oauth2_permission_scope.value.enabled
-        id      = random_uuid.oauth2_permission_scope[oauth2_permission_scope.key].result
+        id      = oauth2_permission_scope.value.id
         type    = oauth2_permission_scope.value.type
 
         user_consent_description  = oauth2_permission_scope.value.user_consent_description
@@ -137,16 +137,6 @@ resource "azuread_application" "this" {
       error_message = "Current client (object ID: \"${data.azuread_client_config.current.object_id}\") must be set as owner."
     }
   }
-}
-
-resource "random_uuid" "oauth2_permission_scope" {
-  // Generate random UUIDs for each permission scope
-  for_each = var.api_oauth2_permission_scopes
-}
-
-resource "random_uuid" "app_role" {
-  // Generate random UUIDs for each app role
-  for_each = var.app_roles
 }
 
 resource "azuread_application_identifier_uri" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "app_roles" {
     allowed_member_types = list(string)
     description          = string
     display_name         = string
-    id                   = string
+    id                   = optional(string) 
     enabled              = bool
     value                = string
   }))
@@ -239,7 +239,7 @@ variable "api_oauth2_permission_scopes" {
     admin_consent_description  = string
     admin_consent_display_name = string
     enabled                    = bool
-    id                         = string
+    id                         = optional(string) 
     type                       = string
     user_consent_description   = optional(string)
     user_consent_display_name  = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,7 @@ variable "app_roles" {
     allowed_member_types = list(string)
     description          = string
     display_name         = string
+    id                   = string
     enabled              = bool
     value                = string
   }))
@@ -238,6 +239,7 @@ variable "api_oauth2_permission_scopes" {
     admin_consent_description  = string
     admin_consent_display_name = string
     enabled                    = bool
+    id                         = string
     type                       = string
     user_consent_description   = optional(string)
     user_consent_display_name  = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -178,6 +178,11 @@ variable "public_client_redirect_uris" {
   description = "A list of URLs where public client (e.g. mobile) OAuth 2.0 autorization codes and access tokens are sent."
   type        = list(string)
   default     = []
+
+  validation {
+    condition     = alltrue([for uri in var.public_client_redirect_uris : can(regex("^https://|^ms-appx-web://", uri))])
+    error_message = "All URIs must be valid HTTPS or ms-appx-web URLs."
+  }
 }
 
 variable "web_implicit_grant_access_token_issuance_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "app_roles" {
     allowed_member_types = list(string)
     description          = string
     display_name         = string
-    id                   = optional(string) 
+    id                   = optional(string)
     enabled              = bool
     value                = string
   }))
@@ -156,11 +156,6 @@ variable "web_redirect_uris" {
   description = "A list of URLs where OAuth 2.0 autorization codes and access tokens are sent."
   type        = list(string)
   default     = []
-
-  validation {
-    condition     = alltrue([for uri in var.web_redirect_uris : can(regex("^https://|^ms-appx-web://|^http://localhost", uri))])
-    error_message = "All URIs must be valid HTTPS URLs excluding localhost."
-  }
 }
 
 variable "single_page_application_redirect_uris" {
@@ -239,7 +234,7 @@ variable "api_oauth2_permission_scopes" {
     admin_consent_description  = string
     admin_consent_display_name = string
     enabled                    = bool
-    id                         = optional(string) 
+    id                         = optional(string)
     type                       = string
     user_consent_description   = optional(string)
     user_consent_display_name  = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -156,6 +156,11 @@ variable "web_redirect_uris" {
   description = "A list of URLs where OAuth 2.0 autorization codes and access tokens are sent."
   type        = list(string)
   default     = []
+
+  validation {
+    condition     = alltrue([for uri in var.web_redirect_uris : can(regex("^https://|^ms-appx-web://|^http://localhost", uri))])
+    error_message = "All URIs must be valid HTTPS URLs excluding localhost."
+  }
 }
 
 variable "single_page_application_redirect_uris" {
@@ -173,11 +178,6 @@ variable "public_client_redirect_uris" {
   description = "A list of URLs where public client (e.g. mobile) OAuth 2.0 autorization codes and access tokens are sent."
   type        = list(string)
   default     = []
-
-  validation {
-    condition     = alltrue([for uri in var.public_client_redirect_uris : can(regex("^https://|^ms-appx-web://", uri))])
-    error_message = "All URIs must be valid HTTPS or ms-appx-web URLs."
-  }
 }
 
 variable "web_implicit_grant_access_token_issuance_enabled" {


### PR DESCRIPTION
Proposal for new changes

I would like to pass the id from outside the module as importing existing resources forces the app_roles block and the Oauth2 block to be recreated.